### PR TITLE
Add descriptive names for CI jobs to enable PR merge restrictions

### DIFF
--- a/.github/workflows/ruby_on_rails_ci.yml
+++ b/.github/workflows/ruby_on_rails_ci.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   build:
+    name: Run Tests
     runs-on: ubuntu-latest
 
     env:


### PR DESCRIPTION
This will help enforce PR merge restrictions requiring successful completion of checks.
(Github settings)